### PR TITLE
Vastaajatunnuksien määrän laskentaan count -> sum

### DIFF
--- a/aipal/src/clj/aipal/arkisto/kyselykerta.clj
+++ b/aipal/src/clj/aipal/arkisto/kyselykerta.clj
@@ -37,7 +37,7 @@
                 [(sql/raw "count(vastaaja.vastaajaid) = 0") :poistettavissa]
                 [(sql/raw "sum(vastaajatunnus.vastaajien_lkm) filter (where vastaajatunnus_kaytettavissa.kaytettavissa)") :aktiivisia_vastaajatunnuksia]
                 [(sql/raw "count(vastaaja.vastaajaid) filter (where vastaajatunnus_kaytettavissa.kaytettavissa)") :aktiivisia_vastaajia]
-                [(sql/raw "count(vastaajatunnus.vastaajien_lkm)") :vastaajatunnuksia]
+                [(sql/raw "sum(vastaajatunnus.vastaajien_lkm)") :vastaajatunnuksia]
                 [(sql/raw "count(vastaaja.vastaajaid)") :vastaajia]
                 [(sql/raw "max(vastaaja.luotuaika)") :viimeisin_vastaus])
     (sql/group :kyselykerta.kyselyid :kyselykerta.kyselykertaid :kyselykerta.nimi


### PR DESCRIPTION
Käyttöliittymässä näytetään
"Vastaajien määrä x/y (z)"

missä

x = kysely.vastaajia
y = kysely.vastaajatunnuksia
z = x/y*100 (vastausprosentti)

Tietokannasta kyseiset muuttujat haetaan seuraavasti (https://github.com/Opetushallitus/aipal/blob/master/aipal/src/clj/aipal/arkisto/kyselykerta.clj#L40)

vastaajia = count(vastaaja.vastaajaid)
vastaajatunnuksia = count(vastaajatunnus.vastaajien_lkm)

Vastaajatunnuksia on siinä mielessä oikein, että kyseinen lukumäärä kuvaa "vastauslinkkien" lukumäärää. Ongelmia tulee siinä vaiheessa, kun samalla tunnuksella vastaajien lukumäärä on suurempi kuin 1, esimerkiksi 10.

Kun vastausprosentti lasketaan jakamalla vastanneiden määrä vastauslinkkien lukumäärällä, jää osa "potentiaalisista vastaajista" huomioimatta.

Jos tuolle "vastauslinkkien" lukumäärälle ei ole todellista käyttöä, niin helpoin korjaus olisi vaihtaa vastaajatunnuksia -laskentaan countin tilalle sum.
